### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To implement SnapSwift in your own project, you need the following four files:
 Furthermore, you need a bridging header with the following import:
 
 ```
-#import <UIKit/UIGestureRecognizerSubclass.h>
+# import <UIKit/UIGestureRecognizerSubclass.h>
 ```
 
 # More Information


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
